### PR TITLE
feat(costs): add durable generationId fields to schema and types

### DIFF
--- a/src/core/execution/costs.ts
+++ b/src/core/execution/costs.ts
@@ -35,6 +35,7 @@ export interface PlanningUsageTotal {
 export interface PlanningAttempt {
   attempt: number;
   reason: 'initial' | 'retry_gaps' | 'retry_parse_error' | 'retry_validation' | 'title_master';
+  generationId?: string;
   usage?: {
     promptTokens?: number;
     completionTokens?: number;
@@ -53,6 +54,7 @@ export interface SubStepCost {
   taskId: string;
   actionType: string;
   toolOrPromptName: string;
+  generationId: string | null;
   usage: UsageInfo | null;
   costUsd: string | null;
 }
@@ -235,6 +237,7 @@ export class CostsService {
           taskId: s.taskId,
           actionType: s.actionType,
           toolOrPromptName: s.toolOrPromptName,
+          generationId: s.generationId ?? null,
           usage: s.usage as UsageInfo | null,
           costUsd: s.costUsd ?? null,
         })),

--- a/src/core/execution/executions.ts
+++ b/src/core/execution/executions.ts
@@ -62,6 +62,7 @@ export interface SubStep {
   } | null;
   costUsd: string | null;
   generationStats: Record<string, any> | null;
+  generationId: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -416,6 +417,7 @@ export class ExecutionsService {
       usage: record.usage,
       costUsd: record.costUsd,
       generationStats: record.generationStats,
+      generationId: record.generationId,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
     };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, sqliteView, text, integer, uniqueIndex } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, sqliteView, text, integer, uniqueIndex, index } from 'drizzle-orm/sqlite-core';
 import { relations } from 'drizzle-orm';
 import { sql } from 'drizzle-orm';
 
@@ -72,6 +72,7 @@ export const dags = sqliteTable('dags', {
   planningAttempts: text('planning_attempts', { mode: 'json' }).$type<Array<{
     attempt: number;
     reason: 'initial' | 'retry_gaps' | 'retry_parse_error' | 'retry_validation' | 'title_master';
+    generationId?: string;
     usage?: {
       promptTokens?: number;
       completionTokens?: number;
@@ -134,50 +135,60 @@ export const dagExecutions = sqliteTable('dag_executions', {
 /**
  * DAG Sub-Steps table
  */
-export const dagSubSteps = sqliteTable('sub_steps', {
-  id: text('id').primaryKey(),
-  executionId: text('execution_id')
-    .notNull()
-    .references(() => dagExecutions.id, { onDelete: 'cascade' }),
+export const dagSubSteps = sqliteTable(
+  'sub_steps',
+  {
+    id: text('id').primaryKey(),
+    executionId: text('execution_id')
+      .notNull()
+      .references(() => dagExecutions.id, { onDelete: 'cascade' }),
 
-  taskId: text('task_id').notNull(),
+    taskId: text('task_id').notNull(),
 
-  description: text('description').notNull(),
-  thought: text('thought').notNull(),
-  actionType: text('action_type', { enum: ['tool', 'inference'] }).notNull(),
+    description: text('description').notNull(),
+    thought: text('thought').notNull(),
+    actionType: text('action_type', { enum: ['tool', 'inference'] }).notNull(),
 
-  toolOrPromptName: text('tool_or_prompt_name').notNull(),
-  toolOrPromptParams: text('tool_or_prompt_params', { mode: 'json' }).$type<Record<string, any>>(),
+    toolOrPromptName: text('tool_or_prompt_name').notNull(),
+    toolOrPromptParams: text('tool_or_prompt_params', { mode: 'json' }).$type<Record<string, any>>(),
 
-  dependencies: text('dependencies', { mode: 'json' }).notNull().$type<string[]>(),
+    dependencies: text('dependencies', { mode: 'json' }).notNull().$type<string[]>(),
 
-  status: text('status', {
-    enum: ['pending', 'running', 'waiting', 'completed', 'failed', 'deleted']
-  }).notNull().default('pending'),
+    status: text('status', {
+      enum: ['pending', 'running', 'waiting', 'completed', 'failed', 'deleted']
+    }).notNull().default('pending'),
 
-  startedAt: integer('started_at', { mode: 'timestamp' }),
-  completedAt: integer('completed_at', { mode: 'timestamp' }),
-  durationMs: integer('duration_ms'),
+    startedAt: integer('started_at', { mode: 'timestamp' }),
+    completedAt: integer('completed_at', { mode: 'timestamp' }),
+    durationMs: integer('duration_ms'),
 
-  result: text('result', { mode: 'json' }).$type<any>(),
-  error: text('error'),
+    result: text('result', { mode: 'json' }).$type<any>(),
+    error: text('error'),
 
-  // Sub-step cost tracking
-  usage: text('usage', { mode: 'json' }).$type<{
-    promptTokens?: number;
-    completionTokens?: number;
-    totalTokens?: number;
-  }>(),
-  costUsd: text('cost_usd'),
-  generationStats: text('generation_stats', { mode: 'json' }).$type<Record<string, any>>(),
+    // Sub-step cost tracking
+    usage: text('usage', { mode: 'json' }).$type<{
+      promptTokens?: number;
+      completionTokens?: number;
+      totalTokens?: number;
+    }>(),
+    costUsd: text('cost_usd'),
+    generationStats: text('generation_stats', { mode: 'json' }).$type<Record<string, any>>(),
+    generationId: text('generation_id'),
 
-  createdAt: integer('created_at', { mode: 'timestamp' })
-    .notNull()
-    .default(sql`(unixepoch())`),
-  updatedAt: integer('updated_at', { mode: 'timestamp' })
-    .notNull()
-    .default(sql`(unixepoch())`),
-});
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .default(sql`(unixepoch())`),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (table) => ({
+    generationIdIdx: index('idx_sub_steps_generation_id').on(table.generationId),
+    pendingStatsIdx: index('idx_sub_steps_pending_stats')
+      .on(table.executionId, table.generationId)
+      .where(sql`${table.generationId} is not null and (${table.costUsd} is null or ${table.generationStats} is null)`),
+  })
+);
 
 /**
  * Executions view - joins dagExecutions with dags to get dagTitle

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -239,6 +239,7 @@ export interface PlanningUsageTotal {
 export interface PlanningAttempt {
   attempt: number;
   reason: 'initial' | 'retry_gaps' | 'retry_parse_error' | 'retry_validation' | 'title_master';
+  generationId?: string;
   usage?: UsageInfo;
   costUsd?: number | null;
   errorMessage?: string;
@@ -264,6 +265,7 @@ export interface ExecutionCostBreakdown {
       taskId: string;
       actionType: string;
       toolOrPromptName: string;
+      generationId: string | null;
       usage: UsageInfo | null;
       costUsd: string | null;
     }>;

--- a/src/types/execution.ts
+++ b/src/types/execution.ts
@@ -143,6 +143,7 @@ export interface SubStep {
   } | null;
   costUsd: string | null;
   generationStats: Record<string, any> | null;
+  generationId: string | null;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
Amp-Thread-ID: https://ampcode.com/threads/T-019ce136-91eb-751a-8ba2-7272f81ab47a

## Summary
Persist durable generation identifiers in the data model and expose them in service/client types so delayed reconciliation can be deterministic.

## What Changed
- Added `generationId?: string` to DAG planning attempt shape in [src/db/schema.ts](file:///Users/ugmurthy/riding-amp/desiAgent/src/db/schema.ts).
- Added nullable `generation_id` to `sub_steps` and supporting indexes in [src/db/schema.ts](file:///Users/ugmurthy/riding-amp/desiAgent/src/db/schema.ts).
- Exposed `generationId` in sub-step and planning attempt contracts in [src/core/execution/costs.ts](file:///Users/ugmurthy/riding-amp/desiAgent/src/core/execution/costs.ts), [src/core/execution/executions.ts](file:///Users/ugmurthy/riding-amp/desiAgent/src/core/execution/executions.ts), [src/types/execution.ts](file:///Users/ugmurthy/riding-amp/desiAgent/src/types/execution.ts), and [src/types/client.ts](file:///Users/ugmurthy/riding-amp/desiAgent/src/types/client.ts).

## Why
Batch backfill/reconciliation requires stable generation IDs in storage, not only transient queue payloads.

## Validation
- `bun run type-check`

## Risk
Low. Additive schema and typing updates only.

## Rollback
Revert this PR commit (`f2340f8`).