### PR TITLE
feat(stats): introduce periodic reconciliation worker for eventual co…

### DIFF
--- a/src/core/workers/statsQueue.ts
+++ b/src/core/workers/statsQueue.ts
@@ -12,11 +12,11 @@ import { getLogger } from '../../util/logger.js';
  */
 export interface StatsJob {
   /** Which table to update */
-  table: 'sub_steps' | 'dag_executions' | 'dags';
+  table: 'sub_steps' | 'dag_executions' | 'dags' | 'reconcile';
   /** Row ID in that table (dagId for 'dags', executionId for 'dag_executions') */
   id: string;
   /** OpenRouter generation ID for fetching stats */
-  generationId: string;
+  generationId?: string;
   /**
    * For 'sub_steps': the taskId used with executionId to locate the row.
    */
@@ -36,7 +36,11 @@ export interface StatsJob {
  * Message sent from main thread → worker
  */
 export interface WorkerInMessage {
-  type: 'job' | 'shutdown';
+  type: 'init' | 'job' | 'shutdown';
+  dbPath?: string;
+  apiKey?: string;
+  reconcileIntervalMs?: number;
+  reconcileBatchSize?: number;
   job?: StatsJob;
 }
 
@@ -52,6 +56,13 @@ export interface WorkerOutMessage {
 
 /** Max time (ms) to wait for the worker to drain before force-terminating */
 const DRAIN_TIMEOUT_MS = 30_000;
+const DEFAULT_RECONCILE_INTERVAL_MS = 30_000;
+const DEFAULT_RECONCILE_BATCH_SIZE = 50;
+
+export interface StatsQueueOptions {
+  reconcileIntervalMs?: number;
+  reconcileBatchSize?: number;
+}
 
 export class StatsQueue {
   private worker: Worker | null = null;
@@ -59,10 +70,16 @@ export class StatsQueue {
   private dbPath: string;
   private apiKey: string;
   private pendingCount = 0;
+  private reconcileInFlight = false;
+  private reconcileTimer: ReturnType<typeof setInterval> | null = null;
+  private reconcileIntervalMs: number;
+  private reconcileBatchSize: number;
 
-  constructor(dbPath: string, apiKey: string) {
+  constructor(dbPath: string, apiKey: string, options?: StatsQueueOptions) {
     this.dbPath = dbPath;
     this.apiKey = apiKey;
+    this.reconcileIntervalMs = options?.reconcileIntervalMs ?? DEFAULT_RECONCILE_INTERVAL_MS;
+    this.reconcileBatchSize = options?.reconcileBatchSize ?? DEFAULT_RECONCILE_BATCH_SIZE;
   }
 
   /**
@@ -79,15 +96,23 @@ export class StatsQueue {
       type: 'init',
       dbPath: this.dbPath,
       apiKey: this.apiKey,
+      reconcileIntervalMs: this.reconcileIntervalMs,
+      reconcileBatchSize: this.reconcileBatchSize,
     });
 
     this.worker.onmessage = (event: MessageEvent<WorkerOutMessage>) => {
       const msg = event.data;
       if (msg.type === 'done') {
-        this.pendingCount--;
+        this.pendingCount = Math.max(0, this.pendingCount - 1);
+        if (msg.table === 'reconcile') {
+          this.reconcileInFlight = false;
+        }
         this.logger.debug({ table: msg.table, id: msg.id }, 'StatsWorker: update complete');
       } else if (msg.type === 'error') {
-        this.pendingCount--;
+        this.pendingCount = Math.max(0, this.pendingCount - 1);
+        if (msg.table === 'reconcile') {
+          this.reconcileInFlight = false;
+        }
         this.logger.warn({ table: msg.table, id: msg.id, error: msg.error }, 'StatsWorker: update failed');
       }
       // 'drained' is handled by the terminate() promise listener
@@ -100,7 +125,29 @@ export class StatsQueue {
     // Don't let the worker keep the process alive during normal operation
     this.worker.unref();
 
-    this.logger.info('StatsQueue: background worker started');
+    this.reconcileTimer = setInterval(() => {
+      this.enqueueReconcileTick();
+    }, this.reconcileIntervalMs);
+    this.reconcileTimer.unref?.();
+
+    this.enqueueReconcileTick();
+
+    this.logger.info({
+      reconcileIntervalMs: this.reconcileIntervalMs,
+      reconcileBatchSize: this.reconcileBatchSize,
+    }, 'StatsQueue: background worker started');
+  }
+
+  private enqueueReconcileTick(): void {
+    if (!this.worker || this.reconcileInFlight) {
+      return;
+    }
+
+    this.reconcileInFlight = true;
+    this.enqueue({
+      table: 'reconcile',
+      id: `reconcile_${Date.now()}`,
+    });
   }
 
   /**
@@ -125,6 +172,11 @@ export class StatsQueue {
    */
   async terminate(): Promise<void> {
     if (!this.worker) return;
+
+    if (this.reconcileTimer) {
+      clearInterval(this.reconcileTimer);
+      this.reconcileTimer = null;
+    }
 
     // Fast path: no pending work
     if (this.pendingCount <= 0) {
@@ -163,5 +215,6 @@ export class StatsQueue {
 
     this.worker = null;
     this.pendingCount = 0;
+    this.reconcileInFlight = false;
   }
 }

--- a/src/core/workers/statsWorker.ts
+++ b/src/core/workers/statsWorker.ts
@@ -12,7 +12,7 @@ declare var self: Worker;
 
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, sql } from 'drizzle-orm';
 import * as schema from '../../db/schema.js';
 import { dags, dagExecutions, dagSubSteps } from '../../db/schema.js';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
@@ -21,9 +21,11 @@ import type { StatsJob, WorkerOutMessage } from './statsQueue.js';
 const BASE_URL = 'https://openrouter.ai/api/v1';
 const MAX_FETCH_ATTEMPTS = 5;
 const INITIAL_DELAY_MS = 2000;
+const DEFAULT_RECONCILE_BATCH_SIZE = 50;
 
 let db: BunSQLiteDatabase<typeof schema> | null = null;
 let apiKey: string = '';
+let reconcileBatchSize = DEFAULT_RECONCILE_BATCH_SIZE;
 
 /** Number of jobs currently being processed */
 let pendingCount = 0;
@@ -107,30 +109,62 @@ async function fetchGenerationStats(
  * Uses taskId + executionId as composite key (matching the pattern in DAGExecutor).
  */
 async function updateSubStep(job: StatsJob): Promise<void> {
-  const stats = await fetchGenerationStats(job.generationId);
+  if (job.id.startsWith('reconcile_')) {
+    return;
+  }
+
+  let generationId = job.generationId;
+  if (!generationId) {
+    if (job.taskId && job.executionId) {
+      const existingStep = await db!.query.dagSubSteps.findFirst({
+        where: and(
+          eq(dagSubSteps.taskId, job.taskId),
+          eq(dagSubSteps.executionId, job.executionId),
+        ),
+      });
+      generationId = existingStep?.generationId || undefined;
+    } else {
+      const existingStep = await db!.query.dagSubSteps.findFirst({
+        where: eq(dagSubSteps.id, job.id),
+      });
+      generationId = existingStep?.generationId || undefined;
+    }
+  }
+
+  if (!generationId) return;
+
+  const stats = await fetchGenerationStats(generationId);
   if (stats.error || !stats.data) return;
 
-  if (!job.taskId || !job.executionId) return;
+  if (job.taskId && job.executionId) {
+    await db!.update(dagSubSteps)
+      .set({
+        generationStats: stats.data,
+        costUsd: stats.costUsd?.toString(),
+        generationId,
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(dagSubSteps.taskId, job.taskId),
+        eq(dagSubSteps.executionId, job.executionId),
+      ));
+    return;
+  }
 
   await db!.update(dagSubSteps)
     .set({
       generationStats: stats.data,
       costUsd: stats.costUsd?.toString(),
+      generationId,
       updatedAt: new Date(),
     })
-    .where(and(
-      eq(dagSubSteps.taskId, job.taskId),
-      eq(dagSubSteps.executionId, job.executionId),
-    ));
+    .where(eq(dagSubSteps.id, job.id));
 }
 
 /**
  * Update dag_executions table by re-aggregating costs from all sub_steps.
  */
 async function updateDagExecution(job: StatsJob): Promise<void> {
-  // Wait a moment for any sub_step stats workers to finish first
-  await new Promise(resolve => setTimeout(resolve, 1000));
-
   const allSubSteps = await db!.query.dagSubSteps.findMany({
     where: eq(dagSubSteps.executionId, job.id),
   });
@@ -165,11 +199,131 @@ async function updateDagExecution(job: StatsJob): Promise<void> {
     .where(eq(dagExecutions.id, job.id));
 }
 
+function parseCostUsd(value: unknown): number {
+  if (value == null) return 0;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+
+  const parsed = parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+async function reconcileSubSteps(batchSize: number): Promise<Set<string>> {
+  const unresolvedSubSteps = await db!.select({
+    id: dagSubSteps.id,
+    executionId: dagSubSteps.executionId,
+    generationId: dagSubSteps.generationId,
+  })
+    .from(dagSubSteps)
+    .where(sql`${dagSubSteps.generationId} is not null and (${dagSubSteps.costUsd} is null or ${dagSubSteps.generationStats} is null)`)
+    .limit(batchSize);
+
+  const touchedExecutionIds = new Set<string>();
+
+  for (const step of unresolvedSubSteps) {
+    if (!step.generationId) {
+      continue;
+    }
+
+    const stats = await fetchGenerationStats(step.generationId);
+    if (stats.error || !stats.data) {
+      continue;
+    }
+
+    await db!.update(dagSubSteps)
+      .set({
+        generationStats: stats.data,
+        costUsd: stats.costUsd?.toString(),
+        updatedAt: new Date(),
+      })
+      .where(eq(dagSubSteps.id, step.id));
+
+    touchedExecutionIds.add(step.executionId);
+  }
+
+  return touchedExecutionIds;
+}
+
+async function reconcileDagPlanningAttempts(): Promise<void> {
+  const candidateDags = await db!.select({
+    id: dags.id,
+    planningAttempts: dags.planningAttempts,
+    planningTotalCostUsd: dags.planningTotalCostUsd,
+  })
+    .from(dags)
+    .where(sql`${dags.planningAttempts} is not null`);
+
+  for (const dag of candidateDags) {
+    const attempts = dag.planningAttempts;
+    if (!attempts || attempts.length === 0) {
+      continue;
+    }
+
+    let changed = false;
+    for (const attempt of attempts) {
+      if (!attempt.generationId) {
+        continue;
+      }
+
+      const attemptHasCost = attempt.costUsd != null;
+      const attemptHasStats = !!attempt.generationStats;
+      if (attemptHasCost && attemptHasStats) {
+        continue;
+      }
+
+      const stats = await fetchGenerationStats(attempt.generationId);
+      if (stats.error || !stats.data) {
+        continue;
+      }
+
+      attempt.generationStats = stats.data;
+      attempt.costUsd = stats.costUsd;
+      changed = true;
+    }
+
+    if (!changed) {
+      continue;
+    }
+
+    const totalCost = attempts.reduce((sum, attempt) => sum + parseCostUsd(attempt.costUsd), 0);
+
+    await db!.update(dags)
+      .set({
+        planningAttempts: attempts,
+        planningTotalCostUsd: totalCost.toString(),
+        updatedAt: new Date(),
+      })
+      .where(eq(dags.id, dag.id));
+  }
+}
+
+async function reconcileDagExecutionAggregates(touchedExecutionIds: Set<string>, batchSize: number): Promise<void> {
+  const candidates = await db!.select({ id: dagExecutions.id })
+    .from(dagExecutions)
+    .where(sql`${dagExecutions.completedAt} is not null and (${dagExecutions.totalCostUsd} is null or ${dagExecutions.totalUsage} is null)`)
+    .limit(batchSize);
+
+  for (const row of candidates) {
+    touchedExecutionIds.add(row.id);
+  }
+
+  for (const executionId of touchedExecutionIds) {
+    await updateDagExecution({ table: 'dag_executions', id: executionId });
+  }
+}
+
+async function runReconciliation(batchSize: number): Promise<void> {
+  const touchedExecutionIds = await reconcileSubSteps(batchSize);
+  await reconcileDagPlanningAttempts();
+  await reconcileDagExecutionAggregates(touchedExecutionIds, batchSize);
+}
+
 /**
  * Update dags table: fetch generation stats for a planning attempt
  * and recalculate planning totals.
  */
 async function updateDag(job: StatsJob): Promise<void> {
+  if (!job.generationId) return;
+
   const stats = await fetchGenerationStats(job.generationId);
   if (stats.error || !stats.data) return;
 
@@ -217,6 +371,9 @@ async function processJob(job: StatsJob): Promise<void> {
     case 'dags':
       await updateDag(job);
       break;
+    case 'reconcile':
+      await runReconciliation(reconcileBatchSize);
+      break;
   }
 }
 
@@ -233,6 +390,9 @@ self.onmessage = async (event: MessageEvent) => {
     sqlite.exec('PRAGMA foreign_keys = ON;');
     db = drizzle(sqlite, { schema });
     apiKey = msg.apiKey;
+    reconcileBatchSize = msg.reconcileBatchSize && msg.reconcileBatchSize > 0
+      ? msg.reconcileBatchSize
+      : DEFAULT_RECONCILE_BATCH_SIZE;
     return;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,10 @@ export async function setupDesiAgent(config: DesiAgentConfig): Promise<DesiAgent
     // Initialize background stats worker for OpenRouter
     let statsQueue: StatsQueue | undefined;
     if (resolved.llmProvider === 'openrouter' && !resolved.skipGenerationStats && resolved.apiKey) {
-      statsQueue = new StatsQueue(resolved.databasePath, resolved.apiKey);
+      statsQueue = new StatsQueue(resolved.databasePath, resolved.apiKey, {
+        reconcileIntervalMs: resolved.statsReconcileIntervalMs,
+        reconcileBatchSize: resolved.statsReconcileBatchSize,
+      });
       statsQueue.start();
       logger.info('Background stats worker started for OpenRouter');
     }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -50,6 +50,8 @@ export const DesiAgentConfigSchema = z.object({
   autoStartScheduler: z.boolean().optional().default(true),
   enableToolValidation: z.boolean().optional().default(true),
   skipGenerationStats: z.boolean().optional().default(false),
+  statsReconcileIntervalMs: z.number().int().positive().optional().default(30_000),
+  statsReconcileBatchSize: z.number().int().positive().optional().default(50),
 });
 
 /**
@@ -97,6 +99,8 @@ export interface DesiAgentConfig {
   autoStartScheduler?: boolean;
   enableToolValidation?: boolean;
   skipGenerationStats?: boolean;
+  statsReconcileIntervalMs?: number;
+  statsReconcileBatchSize?: number;
 }
 
 export interface ResolvedConfig {
@@ -136,6 +140,8 @@ export interface ResolvedConfig {
   autoStartScheduler: boolean;
   enableToolValidation: boolean;
   skipGenerationStats: boolean;
+  statsReconcileIntervalMs: number;
+  statsReconcileBatchSize: number;
 }
 
 /**
@@ -174,6 +180,15 @@ export function resolveConfig(validated: z.infer<typeof DesiAgentConfigSchema>):
 
   const logDir = process.env.LOG_DIR || join(homedir(), '.desiAgent', 'logs');
 
+  const statsReconcileIntervalMs = parseInt(
+    process.env.STATS_RECONCILE_INTERVAL_MS || String(validated.statsReconcileIntervalMs),
+    10
+  );
+  const statsReconcileBatchSize = parseInt(
+    process.env.STATS_RECONCILE_BATCH_SIZE || String(validated.statsReconcileBatchSize),
+    10
+  );
+
   return Object.freeze({
     databasePath,
     isMemoryDb,
@@ -211,5 +226,11 @@ export function resolveConfig(validated: z.infer<typeof DesiAgentConfigSchema>):
     autoStartScheduler: validated.autoStartScheduler,
     enableToolValidation: validated.enableToolValidation,
     skipGenerationStats: validated.skipGenerationStats,
+    statsReconcileIntervalMs: Number.isFinite(statsReconcileIntervalMs) && statsReconcileIntervalMs > 0
+      ? statsReconcileIntervalMs
+      : validated.statsReconcileIntervalMs,
+    statsReconcileBatchSize: Number.isFinite(statsReconcileBatchSize) && statsReconcileBatchSize > 0
+      ? statsReconcileBatchSize
+      : validated.statsReconcileBatchSize,
   });
 }


### PR DESCRIPTION
…st consistency

Amp-Thread-ID: https://ampcode.com/threads/T-019ce136-91eb-751a-8ba2-7272f81ab47a

## Summary
Introduces periodic batch reconciliation for generation stats/cost completion and execution aggregate convergence.

## What Changed
- Added periodic reconcile tick support and worker init options in [src/core/workers/statsQueue.ts](file:///Users/ugmurthy/riding-amp/desiAgent/src/core/workers/statsQueue.ts).
- Implemented reconcile jobs for unresolved sub-steps, planning attempts, and execution totals in [src/core/workers/statsWorker.ts](file:///Users/ugmurthy/riding-amp/desiAgent/src/core/workers/statsWorker.ts).
- Added config knobs `statsReconcileIntervalMs` and `statsReconcileBatchSize` in [src/types/config.ts](file:///Users/ugmurthy/riding-amp/desiAgent/src/types/config.ts).
- Wired config into queue construction in [src/index.ts](file:///Users/ugmurthy/riding-amp/desiAgent/src/index.ts).

## Why
Moves from timing-coupled updates to eventual consistency with durable recovery.

## Validation
- `bun run type-check`

## Risk
Medium-high. Background stats semantics change to periodic reconciliation behavior.

## Rollback
Revert this PR commit (`c09b141`).

