### PR TITLE
feat(costs): merge stacked generationId persistence, migration, and reconciler rollout

### DIFF
--- a/src/core/execution/dagExecutor.ts
+++ b/src/core/execution/dagExecutor.ts
@@ -128,7 +128,6 @@ export class DAGExecutor {
   private ollamaBaseUrl?: string;
   private skipGenerationStats?: boolean;
   private skillRegistry?: SkillRegistry;
-  private statsQueue?: StatsQueue;
   private logger = getLogger();
 
   constructor(config: DAGExecutorConfig) {
@@ -140,7 +139,6 @@ export class DAGExecutor {
     this.ollamaBaseUrl = config.ollamaBaseUrl;
     this.skipGenerationStats = config.skipGenerationStats;
     this.skillRegistry = config.skillRegistry;
-    this.statsQueue = config.statsQueue;
 
     this.logger.debug({
       provider: this.llmProvider.name,
@@ -722,21 +720,10 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
                   completedAt: new Date(),
                   durationMs: Date.now() - taskExecStartTime,
                   usage: execResult.usage,
+                  generationId: execResult.generationId,
+                  costUsd: execResult.costUsd?.toString(),
+                  generationStats: execResult.generationStats,
                 };
-
-                // When statsQueue is available, defer stats to background worker
-                if (this.statsQueue && execResult.generationId) {
-                  this.statsQueue.enqueue({
-                    table: 'sub_steps',
-                    id: task.id,
-                    taskId: task.id,
-                    executionId: execId,
-                    generationId: execResult.generationId,
-                  });
-                } else {
-                  subStepUpdate.costUsd = execResult.costUsd?.toString();
-                  subStepUpdate.generationStats = execResult.generationStats;
-                }
 
                 await this.db.update(dagSubSteps)
                   .set(subStepUpdate)
@@ -806,21 +793,10 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
                 completedAt: new Date(),
                 durationMs: Date.now() - wr.startTime,
                 usage: wr.result!.usage,
+                generationId: wr.result!.generationId,
+                costUsd: wr.result!.costUsd?.toString(),
+                generationStats: wr.result!.generationStats,
               };
-
-              // When statsQueue is available, defer stats to background worker
-              if (this.statsQueue && wr.result!.generationId) {
-                this.statsQueue.enqueue({
-                  table: 'sub_steps',
-                  id: wr.taskId,
-                  taskId: wr.taskId,
-                  executionId: execId,
-                  generationId: wr.result!.generationId,
-                });
-              } else {
-                batchUpdate.costUsd = wr.result!.costUsd?.toString();
-                batchUpdate.generationStats = wr.result!.generationStats;
-              }
 
               return this.db.update(dagSubSteps)
                 .set(batchUpdate)
@@ -894,47 +870,23 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
       });
 
       const statusData = this.deriveExecutionStatus(allSubSteps);
+      const totalUsage = this.aggregateUsage(allSubSteps);
+      const totalCostUsd = this.aggregateCost(allSubSteps);
 
-      if (this.statsQueue) {
-        // Write execution status without cost aggregates — worker will fill them in
-        await this.db.update(dagExecutions)
-          .set({
-            status: statusData.status,
-            completedTasks: statusData.completedTasks,
-            failedTasks: statusData.failedTasks,
-            waitingTasks: statusData.waitingTasks,
-            finalResult: validatedResult,
-            synthesisResult: synthesisResult.content,
-            completedAt: new Date(),
-            durationMs: Date.now() - startTime,
-          })
-          .where(eq(dagExecutions.id, execId));
-
-        // Enqueue aggregation to the background worker (generationId not needed for aggregation)
-        this.statsQueue.enqueue({
-          table: 'dag_executions',
-          id: execId,
-          generationId: '',
-        });
-      } else {
-        const totalUsage = this.aggregateUsage(allSubSteps);
-        const totalCostUsd = this.aggregateCost(allSubSteps);
-
-        await this.db.update(dagExecutions)
-          .set({
-            status: statusData.status,
-            completedTasks: statusData.completedTasks,
-            failedTasks: statusData.failedTasks,
-            waitingTasks: statusData.waitingTasks,
-            finalResult: validatedResult,
-            synthesisResult: synthesisResult.content,
-            completedAt: new Date(),
-            durationMs: Date.now() - startTime,
-            totalUsage,
-            totalCostUsd: totalCostUsd?.toString(),
-          })
-          .where(eq(dagExecutions.id, execId));
-      }
+      await this.db.update(dagExecutions)
+        .set({
+          status: statusData.status,
+          completedTasks: statusData.completedTasks,
+          failedTasks: statusData.failedTasks,
+          waitingTasks: statusData.waitingTasks,
+          finalResult: validatedResult,
+          synthesisResult: synthesisResult.content,
+          completedAt: new Date(),
+          durationMs: Date.now() - startTime,
+          totalUsage,
+          totalCostUsd: totalCostUsd?.toString(),
+        })
+        .where(eq(dagExecutions.id, execId));
 
       if (statusData.status === 'completed' || statusData.status === 'partial') {
         this.emitEventIfEnabled(execConfig, {
@@ -1061,18 +1013,6 @@ Generate the final report in Markdown format as specified in the synthesis plan.
     });
 
     const synthesisSubStepId = generateSubStepId();
-    const deferStats = !!(this.statsQueue && response.generationId);
-
-    // When statsQueue is available, defer stats to background worker
-    if (deferStats) {
-      this.statsQueue!.enqueue({
-        table: 'sub_steps',
-        id: '__SYNTHESIS__',
-        taskId: '__SYNTHESIS__',
-        executionId,
-        generationId: response.generationId!,
-      });
-    }
 
     await this.db.insert(dagSubSteps).values({
       id: synthesisSubStepId,
@@ -1089,8 +1029,9 @@ Generate the final report in Markdown format as specified in the synthesis plan.
       completedAt: new Date(),
       durationMs: Date.now() - startTime,
       usage: response.usage,
-      costUsd: deferStats ? undefined : (response as any).costUsd?.toString(),
-      generationStats: deferStats ? undefined : (response as any).generationStats,
+      costUsd: (response as any).costUsd?.toString(),
+      generationStats: (response as any).generationStats,
+      generationId: response.generationId,
       result: response.content,
     });
 

--- a/src/core/execution/dags.ts
+++ b/src/core/execution/dags.ts
@@ -86,6 +86,7 @@ export interface CreateDAGFromGoalOptions {
 interface PlanningAttempt {
   attempt: number;
   reason: 'initial' | 'retry_gaps' | 'retry_parse_error' | 'retry_validation' | 'title_master';
+  generationId?: string;
   usage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number };
   costUsd?: number | null;
   errorMessage?: string;
@@ -441,6 +442,7 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
         planningAttempts.push({
           attempt,
           reason: retryReason,
+          generationId: attemptGenerationId,
           usage: attemptUsage,
           costUsd: attemptCost,
           errorMessage,
@@ -504,6 +506,7 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
         planningAttempts.push({
           attempt,
           reason: retryReason,
+          generationId: attemptGenerationId,
           usage: attemptUsage,
           costUsd: attemptCost,
           errorMessage: JSON.stringify(validatedResult.error.issues),
@@ -563,6 +566,7 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
       planningAttempts.push({
         attempt,
         reason: retryReason,
+        generationId: attemptGenerationId,
         usage: attemptUsage,
         costUsd: attemptCost,
         generationStats: attemptGenStats,
@@ -617,7 +621,7 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
 
         // Fire-and-forget: update title and generation stats in the background
         const titleMasterPromise = this.generateTitleAsync(activeLLMProvider, goalText, options.abortSignal);
-        this.backgroundUpdateDag(dagId, attemptGenStatsPromise, attemptGenerationId, titleMasterPromise, [...planningAttempts], { ...planningUsageTotal }, planningCostTotal, attempt);
+        this.backgroundUpdateDag(dagId, attemptGenStatsPromise, titleMasterPromise, [...planningAttempts], { ...planningUsageTotal }, planningCostTotal, attempt);
 
         return {
           status: 'clarification_required',
@@ -675,7 +679,7 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
 
         // Fire-and-forget: update title and generation stats in the background
         const titleMasterPromise = this.generateTitleAsync(activeLLMProvider, goalText, options.abortSignal);
-        this.backgroundUpdateDag(dagId, attemptGenStatsPromise, attemptGenerationId, titleMasterPromise, [...planningAttempts], { ...planningUsageTotal }, planningCostTotal, attempt);
+        this.backgroundUpdateDag(dagId, attemptGenStatsPromise, titleMasterPromise, [...planningAttempts], { ...planningUsageTotal }, planningCostTotal, attempt);
 
         return { status: 'success', dagId };
       }
@@ -737,7 +741,7 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
 
       // Fire-and-forget: update title and generation stats in the background
       const titleMasterPromise = this.generateTitleAsync(activeLLMProvider, goalText, options.abortSignal);
-      this.backgroundUpdateDag(dagId, attemptGenStatsPromise, attemptGenerationId, titleMasterPromise, [...planningAttempts], { ...planningUsageTotal }, planningCostTotal, attempt);
+      this.backgroundUpdateDag(dagId, attemptGenStatsPromise, titleMasterPromise, [...planningAttempts], { ...planningUsageTotal }, planningCostTotal, attempt);
 
       return { status: 'success', dagId };
     }
@@ -1185,6 +1189,7 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
               usage: result.usage,
               costUsd: result.costUsd?.toString(),
               generationStats: result.generationStats,
+              generationId: result.generationId,
               updatedAt: new Date(),
             })
             .where(eq(dagSubSteps.id, pendingSubStepId));
@@ -1486,6 +1491,7 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
     abortSignal?: AbortSignal
   ): Promise<{
     title: string;
+    generationId?: string;
     usage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number };
     costUsd?: number;
     generationStats?: Record<string, any>;
@@ -1513,6 +1519,7 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
 
       return {
         title,
+        generationId: titleResponse.generationId,
         usage: titleResponse.usage,
         costUsd: (titleResponse as any).costUsd,
         generationStats: (titleResponse as any).generationStats,
@@ -1529,9 +1536,9 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
   private backgroundUpdateDag(
     dagId: string,
     genStatsPromise: Promise<{ generationStats?: Record<string, any>; costUsd?: number }> | undefined,
-    generationId: string | undefined,
     titlePromise: Promise<{
       title: string;
+      generationId?: string;
       usage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number };
       costUsd?: number;
       generationStats?: Record<string, any>;
@@ -1541,16 +1548,9 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
     planningCostTotal: number,
     attempt: number,
   ): void {
-    // When statsQueue is available, offload generation stats to the background worker
-    if (this.statsQueue && generationId) {
-      this.statsQueue.enqueue({
-        table: 'dags',
-        id: dagId,
-        generationId,
-        attemptIndex: planningAttempts.length - 1,
-      });
-
-      // Still handle title in main thread (per requirement)
+    // When statsQueue is available, persist title attempt details and let periodic
+    // reconciliation fill costs/stats using persisted generation IDs.
+    if (this.statsQueue) {
       const run = async () => {
         const updateData: Record<string, any> = {};
 
@@ -1561,6 +1561,7 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
             planningAttempts.push({
               attempt,
               reason: 'title_master',
+              generationId: titleResult.generationId,
               usage: titleResult.usage,
               costUsd: titleResult.costUsd,
               generationStats: titleResult.generationStats,
@@ -1585,7 +1586,7 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
 
         try {
           await this.db.update(dags).set(updateData).where(eq(dags.id, dagId));
-          this.logger.info({ dagId, dagTitle: updateData.dagTitle }, 'Background: DAG updated with title (stats deferred to worker)');
+          this.logger.info({ dagId, dagTitle: updateData.dagTitle }, 'Background: DAG updated with title (stats reconciled periodically)');
         } catch (err) {
           this.logger.error({ err, dagId }, 'Background: failed to update DAG row');
         }
@@ -1624,6 +1625,7 @@ Respond with ONLY the expected output format. Build upon dependencies for cohere
           planningAttempts.push({
             attempt,
             reason: 'title_master',
+            generationId: titleResult.generationId,
             usage: titleResult.usage,
             costUsd: titleResult.costUsd,
             generationStats: titleResult.generationStats,

--- a/src/core/workers/statsQueue.ts
+++ b/src/core/workers/statsQueue.ts
@@ -12,11 +12,11 @@ import { getLogger } from '../../util/logger.js';
  */
 export interface StatsJob {
   /** Which table to update */
-  table: 'sub_steps' | 'dag_executions' | 'dags';
+  table: 'sub_steps' | 'dag_executions' | 'dags' | 'reconcile';
   /** Row ID in that table (dagId for 'dags', executionId for 'dag_executions') */
   id: string;
   /** OpenRouter generation ID for fetching stats */
-  generationId: string;
+  generationId?: string;
   /**
    * For 'sub_steps': the taskId used with executionId to locate the row.
    */
@@ -36,7 +36,11 @@ export interface StatsJob {
  * Message sent from main thread → worker
  */
 export interface WorkerInMessage {
-  type: 'job' | 'shutdown';
+  type: 'init' | 'job' | 'shutdown';
+  dbPath?: string;
+  apiKey?: string;
+  reconcileIntervalMs?: number;
+  reconcileBatchSize?: number;
   job?: StatsJob;
 }
 
@@ -52,6 +56,13 @@ export interface WorkerOutMessage {
 
 /** Max time (ms) to wait for the worker to drain before force-terminating */
 const DRAIN_TIMEOUT_MS = 30_000;
+const DEFAULT_RECONCILE_INTERVAL_MS = 30_000;
+const DEFAULT_RECONCILE_BATCH_SIZE = 50;
+
+export interface StatsQueueOptions {
+  reconcileIntervalMs?: number;
+  reconcileBatchSize?: number;
+}
 
 export class StatsQueue {
   private worker: Worker | null = null;
@@ -59,10 +70,16 @@ export class StatsQueue {
   private dbPath: string;
   private apiKey: string;
   private pendingCount = 0;
+  private reconcileInFlight = false;
+  private reconcileTimer: ReturnType<typeof setInterval> | null = null;
+  private reconcileIntervalMs: number;
+  private reconcileBatchSize: number;
 
-  constructor(dbPath: string, apiKey: string) {
+  constructor(dbPath: string, apiKey: string, options?: StatsQueueOptions) {
     this.dbPath = dbPath;
     this.apiKey = apiKey;
+    this.reconcileIntervalMs = options?.reconcileIntervalMs ?? DEFAULT_RECONCILE_INTERVAL_MS;
+    this.reconcileBatchSize = options?.reconcileBatchSize ?? DEFAULT_RECONCILE_BATCH_SIZE;
   }
 
   /**
@@ -79,15 +96,23 @@ export class StatsQueue {
       type: 'init',
       dbPath: this.dbPath,
       apiKey: this.apiKey,
+      reconcileIntervalMs: this.reconcileIntervalMs,
+      reconcileBatchSize: this.reconcileBatchSize,
     });
 
     this.worker.onmessage = (event: MessageEvent<WorkerOutMessage>) => {
       const msg = event.data;
       if (msg.type === 'done') {
-        this.pendingCount--;
+        this.pendingCount = Math.max(0, this.pendingCount - 1);
+        if (msg.table === 'reconcile') {
+          this.reconcileInFlight = false;
+        }
         this.logger.debug({ table: msg.table, id: msg.id }, 'StatsWorker: update complete');
       } else if (msg.type === 'error') {
-        this.pendingCount--;
+        this.pendingCount = Math.max(0, this.pendingCount - 1);
+        if (msg.table === 'reconcile') {
+          this.reconcileInFlight = false;
+        }
         this.logger.warn({ table: msg.table, id: msg.id, error: msg.error }, 'StatsWorker: update failed');
       }
       // 'drained' is handled by the terminate() promise listener
@@ -100,7 +125,29 @@ export class StatsQueue {
     // Don't let the worker keep the process alive during normal operation
     this.worker.unref();
 
-    this.logger.info('StatsQueue: background worker started');
+    this.reconcileTimer = setInterval(() => {
+      this.enqueueReconcileTick();
+    }, this.reconcileIntervalMs);
+    this.reconcileTimer.unref?.();
+
+    this.enqueueReconcileTick();
+
+    this.logger.info({
+      reconcileIntervalMs: this.reconcileIntervalMs,
+      reconcileBatchSize: this.reconcileBatchSize,
+    }, 'StatsQueue: background worker started');
+  }
+
+  private enqueueReconcileTick(): void {
+    if (!this.worker || this.reconcileInFlight) {
+      return;
+    }
+
+    this.reconcileInFlight = true;
+    this.enqueue({
+      table: 'reconcile',
+      id: `reconcile_${Date.now()}`,
+    });
   }
 
   /**
@@ -125,6 +172,11 @@ export class StatsQueue {
    */
   async terminate(): Promise<void> {
     if (!this.worker) return;
+
+    if (this.reconcileTimer) {
+      clearInterval(this.reconcileTimer);
+      this.reconcileTimer = null;
+    }
 
     // Fast path: no pending work
     if (this.pendingCount <= 0) {
@@ -163,5 +215,6 @@ export class StatsQueue {
 
     this.worker = null;
     this.pendingCount = 0;
+    this.reconcileInFlight = false;
   }
 }

--- a/src/core/workers/statsWorker.ts
+++ b/src/core/workers/statsWorker.ts
@@ -12,7 +12,7 @@ declare var self: Worker;
 
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, sql } from 'drizzle-orm';
 import * as schema from '../../db/schema.js';
 import { dags, dagExecutions, dagSubSteps } from '../../db/schema.js';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
@@ -21,9 +21,11 @@ import type { StatsJob, WorkerOutMessage } from './statsQueue.js';
 const BASE_URL = 'https://openrouter.ai/api/v1';
 const MAX_FETCH_ATTEMPTS = 5;
 const INITIAL_DELAY_MS = 2000;
+const DEFAULT_RECONCILE_BATCH_SIZE = 50;
 
 let db: BunSQLiteDatabase<typeof schema> | null = null;
 let apiKey: string = '';
+let reconcileBatchSize = DEFAULT_RECONCILE_BATCH_SIZE;
 
 /** Number of jobs currently being processed */
 let pendingCount = 0;
@@ -107,30 +109,62 @@ async function fetchGenerationStats(
  * Uses taskId + executionId as composite key (matching the pattern in DAGExecutor).
  */
 async function updateSubStep(job: StatsJob): Promise<void> {
-  const stats = await fetchGenerationStats(job.generationId);
+  if (job.id.startsWith('reconcile_')) {
+    return;
+  }
+
+  let generationId = job.generationId;
+  if (!generationId) {
+    if (job.taskId && job.executionId) {
+      const existingStep = await db!.query.dagSubSteps.findFirst({
+        where: and(
+          eq(dagSubSteps.taskId, job.taskId),
+          eq(dagSubSteps.executionId, job.executionId),
+        ),
+      });
+      generationId = existingStep?.generationId || undefined;
+    } else {
+      const existingStep = await db!.query.dagSubSteps.findFirst({
+        where: eq(dagSubSteps.id, job.id),
+      });
+      generationId = existingStep?.generationId || undefined;
+    }
+  }
+
+  if (!generationId) return;
+
+  const stats = await fetchGenerationStats(generationId);
   if (stats.error || !stats.data) return;
 
-  if (!job.taskId || !job.executionId) return;
+  if (job.taskId && job.executionId) {
+    await db!.update(dagSubSteps)
+      .set({
+        generationStats: stats.data,
+        costUsd: stats.costUsd?.toString(),
+        generationId,
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(dagSubSteps.taskId, job.taskId),
+        eq(dagSubSteps.executionId, job.executionId),
+      ));
+    return;
+  }
 
   await db!.update(dagSubSteps)
     .set({
       generationStats: stats.data,
       costUsd: stats.costUsd?.toString(),
+      generationId,
       updatedAt: new Date(),
     })
-    .where(and(
-      eq(dagSubSteps.taskId, job.taskId),
-      eq(dagSubSteps.executionId, job.executionId),
-    ));
+    .where(eq(dagSubSteps.id, job.id));
 }
 
 /**
  * Update dag_executions table by re-aggregating costs from all sub_steps.
  */
 async function updateDagExecution(job: StatsJob): Promise<void> {
-  // Wait a moment for any sub_step stats workers to finish first
-  await new Promise(resolve => setTimeout(resolve, 1000));
-
   const allSubSteps = await db!.query.dagSubSteps.findMany({
     where: eq(dagSubSteps.executionId, job.id),
   });
@@ -165,11 +199,131 @@ async function updateDagExecution(job: StatsJob): Promise<void> {
     .where(eq(dagExecutions.id, job.id));
 }
 
+function parseCostUsd(value: unknown): number {
+  if (value == null) return 0;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+
+  const parsed = parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+async function reconcileSubSteps(batchSize: number): Promise<Set<string>> {
+  const unresolvedSubSteps = await db!.select({
+    id: dagSubSteps.id,
+    executionId: dagSubSteps.executionId,
+    generationId: dagSubSteps.generationId,
+  })
+    .from(dagSubSteps)
+    .where(sql`${dagSubSteps.generationId} is not null and (${dagSubSteps.costUsd} is null or ${dagSubSteps.generationStats} is null)`)
+    .limit(batchSize);
+
+  const touchedExecutionIds = new Set<string>();
+
+  for (const step of unresolvedSubSteps) {
+    if (!step.generationId) {
+      continue;
+    }
+
+    const stats = await fetchGenerationStats(step.generationId);
+    if (stats.error || !stats.data) {
+      continue;
+    }
+
+    await db!.update(dagSubSteps)
+      .set({
+        generationStats: stats.data,
+        costUsd: stats.costUsd?.toString(),
+        updatedAt: new Date(),
+      })
+      .where(eq(dagSubSteps.id, step.id));
+
+    touchedExecutionIds.add(step.executionId);
+  }
+
+  return touchedExecutionIds;
+}
+
+async function reconcileDagPlanningAttempts(): Promise<void> {
+  const candidateDags = await db!.select({
+    id: dags.id,
+    planningAttempts: dags.planningAttempts,
+    planningTotalCostUsd: dags.planningTotalCostUsd,
+  })
+    .from(dags)
+    .where(sql`${dags.planningAttempts} is not null`);
+
+  for (const dag of candidateDags) {
+    const attempts = dag.planningAttempts;
+    if (!attempts || attempts.length === 0) {
+      continue;
+    }
+
+    let changed = false;
+    for (const attempt of attempts) {
+      if (!attempt.generationId) {
+        continue;
+      }
+
+      const attemptHasCost = attempt.costUsd != null;
+      const attemptHasStats = !!attempt.generationStats;
+      if (attemptHasCost && attemptHasStats) {
+        continue;
+      }
+
+      const stats = await fetchGenerationStats(attempt.generationId);
+      if (stats.error || !stats.data) {
+        continue;
+      }
+
+      attempt.generationStats = stats.data;
+      attempt.costUsd = stats.costUsd;
+      changed = true;
+    }
+
+    if (!changed) {
+      continue;
+    }
+
+    const totalCost = attempts.reduce((sum, attempt) => sum + parseCostUsd(attempt.costUsd), 0);
+
+    await db!.update(dags)
+      .set({
+        planningAttempts: attempts,
+        planningTotalCostUsd: totalCost.toString(),
+        updatedAt: new Date(),
+      })
+      .where(eq(dags.id, dag.id));
+  }
+}
+
+async function reconcileDagExecutionAggregates(touchedExecutionIds: Set<string>, batchSize: number): Promise<void> {
+  const candidates = await db!.select({ id: dagExecutions.id })
+    .from(dagExecutions)
+    .where(sql`${dagExecutions.completedAt} is not null and (${dagExecutions.totalCostUsd} is null or ${dagExecutions.totalUsage} is null)`)
+    .limit(batchSize);
+
+  for (const row of candidates) {
+    touchedExecutionIds.add(row.id);
+  }
+
+  for (const executionId of touchedExecutionIds) {
+    await updateDagExecution({ table: 'dag_executions', id: executionId });
+  }
+}
+
+async function runReconciliation(batchSize: number): Promise<void> {
+  const touchedExecutionIds = await reconcileSubSteps(batchSize);
+  await reconcileDagPlanningAttempts();
+  await reconcileDagExecutionAggregates(touchedExecutionIds, batchSize);
+}
+
 /**
  * Update dags table: fetch generation stats for a planning attempt
  * and recalculate planning totals.
  */
 async function updateDag(job: StatsJob): Promise<void> {
+  if (!job.generationId) return;
+
   const stats = await fetchGenerationStats(job.generationId);
   if (stats.error || !stats.data) return;
 
@@ -217,6 +371,9 @@ async function processJob(job: StatsJob): Promise<void> {
     case 'dags':
       await updateDag(job);
       break;
+    case 'reconcile':
+      await runReconciliation(reconcileBatchSize);
+      break;
   }
 }
 
@@ -233,6 +390,9 @@ self.onmessage = async (event: MessageEvent) => {
     sqlite.exec('PRAGMA foreign_keys = ON;');
     db = drizzle(sqlite, { schema });
     apiKey = msg.apiKey;
+    reconcileBatchSize = msg.reconcileBatchSize && msg.reconcileBatchSize > 0
+      ? msg.reconcileBatchSize
+      : DEFAULT_RECONCILE_BATCH_SIZE;
     return;
   }
 

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -30,6 +30,82 @@ function initializeTables(sqlite: any, logger: any): void {
   }
 }
 
+function hasColumn(sqlite: any, tableName: string, columnName: string): boolean {
+  const rows = sqlite.query(`PRAGMA table_info(${tableName});`).all() as Array<{ name?: string }>;
+  return rows.some((row) => row.name === columnName);
+}
+
+function backfillPlanningAttemptGenerationIds(sqlite: any, logger: any): void {
+  const rows = sqlite
+    .query("SELECT id, planning_attempts AS planningAttempts FROM dags WHERE planning_attempts IS NOT NULL;")
+    .all() as Array<{ id: string; planningAttempts: string | null }>;
+
+  if (rows.length === 0) {
+    return;
+  }
+
+  const updateStmt = sqlite.prepare(
+    'UPDATE dags SET planning_attempts = ?, updated_at = (unixepoch()) WHERE id = ?;'
+  );
+
+  let updatedRows = 0;
+
+  for (const row of rows) {
+    if (!row.planningAttempts) {
+      continue;
+    }
+
+    try {
+      const attempts = JSON.parse(row.planningAttempts) as Array<Record<string, any>>;
+      if (!Array.isArray(attempts)) {
+        continue;
+      }
+
+      let changed = false;
+      for (const attempt of attempts) {
+        if (attempt?.generationId) {
+          continue;
+        }
+
+        const attemptGenerationId = attempt?.generationStats?.id;
+        if (typeof attemptGenerationId === 'string' && attemptGenerationId.length > 0) {
+          attempt.generationId = attemptGenerationId;
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        updateStmt.run(JSON.stringify(attempts), row.id);
+        updatedRows += 1;
+      }
+    } catch {
+      // Ignore malformed rows and continue migrating best-effort.
+    }
+  }
+
+  if (updatedRows > 0) {
+    logger.info({ updatedRows }, 'Backfilled planning attempt generation IDs');
+  }
+}
+
+function runRuntimeMigrations(sqlite: any, logger: any): void {
+  if (!hasColumn(sqlite, 'sub_steps', 'generation_id')) {
+    sqlite.exec('ALTER TABLE sub_steps ADD COLUMN generation_id TEXT;');
+    logger.info('Applied migration: added sub_steps.generation_id');
+  }
+
+  sqlite.exec('CREATE INDEX IF NOT EXISTS idx_sub_steps_generation_id ON sub_steps(generation_id);');
+  sqlite.exec(
+    'CREATE INDEX IF NOT EXISTS idx_sub_steps_pending_stats ON sub_steps(execution_id, generation_id) WHERE generation_id IS NOT NULL AND (cost_usd IS NULL OR generation_stats IS NULL);'
+  );
+
+  sqlite.exec(
+    "UPDATE sub_steps SET generation_id = json_extract(generation_stats, '$.id') WHERE generation_id IS NULL AND generation_stats IS NOT NULL AND json_extract(generation_stats, '$.id') IS NOT NULL;"
+  );
+
+  backfillPlanningAttemptGenerationIds(sqlite, logger);
+}
+
 /**
  * Create and initialize database connection
  */
@@ -57,6 +133,7 @@ function createDatabase(dbPath: string, isMemoryDb: boolean): DrizzleDB {
 
     // Always initialize tables
     initializeTables(sqlite, logger);
+    runRuntimeMigrations(sqlite, logger);
 
     const db = drizzle(sqlite, { schema });
     logger.info(`Database initialized: ${dbPath}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,10 @@ export async function setupDesiAgent(config: DesiAgentConfig): Promise<DesiAgent
     // Initialize background stats worker for OpenRouter
     let statsQueue: StatsQueue | undefined;
     if (resolved.llmProvider === 'openrouter' && !resolved.skipGenerationStats && resolved.apiKey) {
-      statsQueue = new StatsQueue(resolved.databasePath, resolved.apiKey);
+      statsQueue = new StatsQueue(resolved.databasePath, resolved.apiKey, {
+        reconcileIntervalMs: resolved.statsReconcileIntervalMs,
+        reconcileBatchSize: resolved.statsReconcileBatchSize,
+      });
       statsQueue.start();
       logger.info('Background stats worker started for OpenRouter');
     }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -50,6 +50,8 @@ export const DesiAgentConfigSchema = z.object({
   autoStartScheduler: z.boolean().optional().default(true),
   enableToolValidation: z.boolean().optional().default(true),
   skipGenerationStats: z.boolean().optional().default(false),
+  statsReconcileIntervalMs: z.number().int().positive().optional().default(30_000),
+  statsReconcileBatchSize: z.number().int().positive().optional().default(50),
 });
 
 /**
@@ -97,6 +99,8 @@ export interface DesiAgentConfig {
   autoStartScheduler?: boolean;
   enableToolValidation?: boolean;
   skipGenerationStats?: boolean;
+  statsReconcileIntervalMs?: number;
+  statsReconcileBatchSize?: number;
 }
 
 export interface ResolvedConfig {
@@ -136,6 +140,8 @@ export interface ResolvedConfig {
   autoStartScheduler: boolean;
   enableToolValidation: boolean;
   skipGenerationStats: boolean;
+  statsReconcileIntervalMs: number;
+  statsReconcileBatchSize: number;
 }
 
 /**
@@ -174,6 +180,15 @@ export function resolveConfig(validated: z.infer<typeof DesiAgentConfigSchema>):
 
   const logDir = process.env.LOG_DIR || join(homedir(), '.desiAgent', 'logs');
 
+  const statsReconcileIntervalMs = parseInt(
+    process.env.STATS_RECONCILE_INTERVAL_MS || String(validated.statsReconcileIntervalMs),
+    10
+  );
+  const statsReconcileBatchSize = parseInt(
+    process.env.STATS_RECONCILE_BATCH_SIZE || String(validated.statsReconcileBatchSize),
+    10
+  );
+
   return Object.freeze({
     databasePath,
     isMemoryDb,
@@ -211,5 +226,11 @@ export function resolveConfig(validated: z.infer<typeof DesiAgentConfigSchema>):
     autoStartScheduler: validated.autoStartScheduler,
     enableToolValidation: validated.enableToolValidation,
     skipGenerationStats: validated.skipGenerationStats,
+    statsReconcileIntervalMs: Number.isFinite(statsReconcileIntervalMs) && statsReconcileIntervalMs > 0
+      ? statsReconcileIntervalMs
+      : validated.statsReconcileIntervalMs,
+    statsReconcileBatchSize: Number.isFinite(statsReconcileBatchSize) && statsReconcileBatchSize > 0
+      ? statsReconcileBatchSize
+      : validated.statsReconcileBatchSize,
   });
 }


### PR DESCRIPTION
## Summary
Final stack merge for generationId persistence and eventual-consistency cost reconciliation.

## Includes
- PR1: schema/type support for durable `generationId`
- PR2: write-path persistence in planning/title/sub-steps/synthesis/redo
- PR3: runtime migration + historical backfill
- PR4: periodic reconciliation worker and config wiring

## Validation
- `bun run type-check`

## Notes
This final PR is intended to land the stacked commits into `main` in one merge.

Click Create pull request.
Click Merge pull request and Confirm merge.

